### PR TITLE
Update Dockerfile's curl permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /bin
 
 ADD curl-amd64 curl
 
-RUN chmod u+x /bin/curl
+RUN chmod +x /bin/curl
 
 RUN export PATH=$PATH:/bin/curl
 


### PR DESCRIPTION
Make curl executable for all users.
This accounts for cases where containers are deployed without using the root user (e.g. Red Hat OpenShift Container Platform)